### PR TITLE
CompactSize should allow for 0

### DIFF
--- a/11_unit_testing.md
+++ b/11_unit_testing.md
@@ -200,27 +200,12 @@ fn test_reading_compact_size() {
     }
 ```
 
-That checks out! Neat. Let's add another test to account for the scenario in which the program `panic!`s. Since a `panic!` will cause the program to crash, we need a way of catching that when it happens and then checking the result. 
-
-One way we can do this is with `std::panic::catch_unwind` which will take the code we want to run as a `closure` and return an `Err` `Result` if a `panic!` is reached. We'll talk more about the `Result` enum later on. For now just know that there's a method, `is_err`, that will check if the `Result` is the `Err` type. And if you're not familiar with closures, you can read more about them [here](https://doc.rust-lang.org/book/ch13-01-closures.html). These are essentially anonymous functions that we can pass into another function as an argument. 
-
-```rust
-let result = std::panic::catch_unwind(|| {
-    let mut bytes = [0_u8].as_slice();
-    read_compact_size(&mut bytes);
-});
-assert!(result.is_err());
-```
-
-This is the only scenario in which the code will panic. We won't be able to pass in a number greater than 255 because we've ensured that the input type is a `u8` and the maximum number for a `u8` is 255. So the only value that will actually cause the program to crash is 0.
-
 Run this with `cargo test` and all the tests should pass!
 
 Great! We've learned about unit testing. We'll keep this in mind as we write more functions with complex logic. Let's keep it moving and keep reading the transaction.
 
 ### Additional Reading
 * Test Organization: https://doc.rust-lang.org/book/ch11-03-test-organization.html
-* Closures: https://doc.rust-lang.org/book/ch13-01-closures.html
 
 <hr/>
 

--- a/code/transaction_decoder_10/src/main.rs
+++ b/code/transaction_decoder_10/src/main.rs
@@ -13,9 +13,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -30,9 +28,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");          
         }
     }
 }

--- a/code/transaction_decoder_11/src/main.rs
+++ b/code/transaction_decoder_11/src/main.rs
@@ -12,9 +12,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -29,9 +27,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -78,11 +73,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_12/src/main.rs
+++ b/code/transaction_decoder_12/src/main.rs
@@ -12,9 +12,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -29,9 +27,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -99,11 +94,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_13/src/main.rs
+++ b/code/transaction_decoder_13/src/main.rs
@@ -20,9 +20,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -37,9 +35,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -115,11 +110,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_14/src/main.rs
+++ b/code/transaction_decoder_14/src/main.rs
@@ -27,9 +27,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -44,9 +42,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -126,11 +121,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_15/src/main.rs
+++ b/code/transaction_decoder_15/src/main.rs
@@ -49,9 +49,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -66,9 +64,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -165,11 +160,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_16/src/main.rs
+++ b/code/transaction_decoder_16/src/main.rs
@@ -60,9 +60,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -77,9 +75,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -176,11 +171,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_17/src/main.rs
+++ b/code/transaction_decoder_17/src/main.rs
@@ -21,9 +21,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -38,9 +36,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -137,11 +132,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_18/src/main.rs
+++ b/code/transaction_decoder_18/src/main.rs
@@ -22,9 +22,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
     transaction_bytes.read(&mut compact_size).unwrap();
 
     match compact_size[0] {
-        1..=252 => {
-            compact_size[0] as u64
-        },
+        0..=252 => compact_size[0] as u64,
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer).unwrap();
@@ -39,9 +37,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> u64 {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer).unwrap();
             u64::from_le_bytes(buffer)
-        },
-        _ => {
-            panic!("invalid compact size");
         }
     }
 }
@@ -164,11 +159,5 @@ mod unit_tests {
         let length = read_compact_size(&mut bytes);
         let expected_length = 20_000_u64;
         assert_eq!(length, expected_length);
-
-        let result = std::panic::catch_unwind(|| {
-            let mut bytes = [0_u8].as_slice();
-            read_compact_size(&mut bytes);
-        });
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_19/src/lib.rs
+++ b/code/transaction_decoder_19/src/lib.rs
@@ -3,7 +3,7 @@ mod transaction;
 use self::transaction::{Amount, Input, Output, Transaction, Txid};
 use sha2::{Digest, Sha256};
 use std::error::Error;
-use std::io::{Error as IOError, ErrorKind};
+use std::io::{Error as IOError};
 
 fn read_u32(transaction_bytes: &mut &[u8]) -> Result<u32, IOError> {
     let mut buffer = [0; 4];
@@ -24,9 +24,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> Result<u64, IOError> {
     transaction_bytes.read(&mut compact_size)?;
 
     match compact_size[0] {
-        1..=252 => {
-            Ok(compact_size[0] as u64)
-        },
+        0..=252 => Ok(compact_size[0] as u64),
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer)?;
@@ -41,9 +39,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> Result<u64, IOError> {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer)?;
             Ok(u64::from_le_bytes(buffer))
-        },
-        _ => {
-            Err(IOError::new(ErrorKind::InvalidInput, "invalid compact size"))
         }
     }
 }
@@ -170,9 +165,5 @@ mod unit_tests {
         let expected_length = 20_000_u64;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_length);
-
-        let mut bytes = [0_u8].as_slice();
-        let result = read_compact_size(&mut bytes);
-        assert!(result.is_err());
     }
 }

--- a/code/transaction_decoder_20/src/lib.rs
+++ b/code/transaction_decoder_20/src/lib.rs
@@ -3,7 +3,7 @@ mod transaction;
 use self::transaction::{Amount, Input, Output, Transaction, Txid};
 use sha2::{Digest, Sha256};
 use std::error::Error;
-use std::io::{Error as IOError, ErrorKind};
+use std::io::{Error as IOError};
 use clap::{arg, value_parser, Command};
 
 fn read_u32(transaction_bytes: &mut &[u8]) -> Result<u32, IOError> {
@@ -25,9 +25,7 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> Result<u64, IOError> {
     transaction_bytes.read(&mut compact_size)?;
 
     match compact_size[0] {
-        1..=252 => {
-            Ok(compact_size[0] as u64)
-        },
+        0..=252 => Ok(compact_size[0] as u64),
         253 => {
             let mut buffer = [0; 2];
             transaction_bytes.read(&mut buffer)?;
@@ -42,9 +40,6 @@ fn read_compact_size(transaction_bytes: &mut &[u8]) -> Result<u64, IOError> {
             let mut buffer = [0; 8];
             transaction_bytes.read(&mut buffer)?;
             Ok(u64::from_le_bytes(buffer))
-        },
-        _ => {
-            Err(IOError::new(ErrorKind::InvalidInput, "Compact size error: invalid compact size"))
         }
     }
 }
@@ -188,9 +183,5 @@ mod unit_tests {
         let expected_length = 20_000_u64;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_length);
-
-        let mut bytes = [0_u8].as_slice();
-        let result = read_compact_size(&mut bytes);
-        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Resolves https://github.com/sb1752/bitcoiner-intro-to-rust/issues/27

- [x] Ran `cargo run` on every code snapshot
- [x] Ran `cargo test` on every code snapshot

This will avoid confusion later on in chapter 22 when we have to move everything over to `transaction.rs` and use the `compactSize` to determine if there are zero inputs in order to run segwit logic. 

```rust
impl Decodable for Transaction {
    fn consensus_decode<R: Read>(r: &mut R) -> Result<Self, Error> {
        let version = Version::consensus_decode(r)?;
        let inputs = Vec::<TxIn>::consensus_decode(r)?;
        if inputs.is_empty() {
            let segwit_flag = u8::consensus_decode(r)?;
            match segwit_flag {
                1 => {
                    let mut inputs = Vec::<TxIn>::consensus_decode(r)?;
                    let outputs = Vec::<TxOut>::consensus_decode(r)?;
                    for txin in inputs.iter_mut() {
                        txin.witness = Witness::consensus_decode(r)?;
                    }
                    if !inputs.is_empty() && inputs.iter().all(|input| input.witness.is_empty()) {
                        Err(Error::ParseFailed("witness flag set but no witnesses present"))
                    } else {
                        Ok(Transaction {
                            version,
                            inputs,
                            outputs,
                            lock_time: u32::consensus_decode(r)?,
                        })
                    }
                }
                // We don't support anything else
                x => Err(Error::UnsupportedSegwitFlag(x)),
            }
        // non-segwit
        } else {
            Ok(Transaction {
                version,
                inputs,
                outputs: Vec::<TxOut>::consensus_decode(r)?,
                lock_time: u32::consensus_decode(r)?,
            })
        }        
    }
}
```